### PR TITLE
Allow theming via the configuration of the reader

### DIFF
--- a/configs/example_config.yaml
+++ b/configs/example_config.yaml
@@ -24,11 +24,13 @@ Application:
 # Configuration of the theming
 # Currently only the configuration of colors is implemented
 Theme:
-  PrimaryColor: "62"
-  SecondaryColor: "230"
+  PrimaryColor: "#3636D1"
+  SecondaryColor: "#F8F8F2"
   NormalTitleColor: "#DDDDDD"
   NormalDescColor: "#777777"
   SelectedPrimaryColor: "#AD58B4"
   SelectedSecondaryColor: "#EE6FF8"
   BreakingColor: "#FF0000"
+  ReaderHighlightColor: "#FFB86C"
+  ReaderHeadingColor: "#BD93F9"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -21,6 +20,8 @@ type ThemeConfig struct {
 	SelectedPrimaryColor   string `yaml:"SelectedPrimaryColor"`
 	SelectedSecondaryColor string `yaml:"SelectedSecondaryColor"`
 	BreakingColor          string `yaml:"BreakingColor"`
+	ReaderHighlightColor   string `yaml:"ReaderHighlightColor"`
+	ReaderHeadingColor     string `yaml:"ReaderHeadingColor"`
 }
 
 type ApplicationsConfig struct {
@@ -62,13 +63,9 @@ func (c Config) Load() Configuration {
 
 	data, err := os.ReadFile(c.file)
 	if err != nil {
-		fmt.Println(err)
 		return config
 	}
 
-	err = yaml.Unmarshal(data, &config)
-	if err != nil {
-		fmt.Println(err)
-	}
+	_ = yaml.Unmarshal(data, &config)
 	return config
 }

--- a/pkg/config/glamour.go
+++ b/pkg/config/glamour.go
@@ -2,220 +2,118 @@ package config
 
 import "github.com/charmbracelet/glamour/ansi"
 
-var NachrichtenStyleConfig = ansi.StyleConfig{
-	Document: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			BlockPrefix: "\n",
-			BlockSuffix: "\n",
-			Color:       stringPtr("#f8f8f2"),
-		},
-		Margin: uintPtr(2),
-	},
-	BlockQuote: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Color:  stringPtr("#f1fa8c"),
-			Italic: boolPtr(true),
-		},
-		Indent:      uintPtr(1),
-		IndentToken: stringPtr("| "),
-	},
-	List: ansi.StyleList{
-		LevelIndent: 2,
-	},
-	Heading: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			BlockSuffix: "\n",
-			Color:       stringPtr("#bd93f9"),
-			Bold:        boolPtr(true),
-		},
-	},
-	H1: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Prefix:          "",
-			Suffix:          "",
-			Color:           stringPtr("#bd93f9"),
-			BackgroundColor: stringPtr("#bd93f9"),
-			Bold:            boolPtr(true),
-		},
-	},
-	H2: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "| ",
-		},
-	},
-	H3: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "",
-		},
-	},
-	H4: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "",
-		},
-	},
-	H5: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "",
-		},
-	},
-	H6: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "",
-			Color:  stringPtr("#bd93f9"),
-			Bold:   boolPtr(false),
-		},
-	},
-	Strikethrough: ansi.StylePrimitive{
-		CrossedOut: boolPtr(true),
-	},
-	Emph: ansi.StylePrimitive{
-		Italic: boolPtr(true),
-	},
-	Strong: ansi.StylePrimitive{
-		Bold:  boolPtr(true),
-		Color: stringPtr("#ffb86c"),
-	},
-	HorizontalRule: ansi.StylePrimitive{
-		Color:  stringPtr("#6272A4"),
-		Format: "\n--------\n",
-	},
-	Item: ansi.StylePrimitive{
-		BlockPrefix: "• ",
-	},
-	Enumeration: ansi.StylePrimitive{
-		BlockPrefix: ". ",
-		Color:       stringPtr("#8be9fd"),
-	},
-	Task: ansi.StyleTask{
-		StylePrimitive: ansi.StylePrimitive{},
-		Ticked:         "[✓] ",
-		Unticked:       "[ ] ",
-	},
-	Link: ansi.StylePrimitive{
-		Color:     stringPtr("#8be9fd"),
-		Underline: boolPtr(true),
-	},
-	LinkText: ansi.StylePrimitive{
-		Color: stringPtr("#ff79c6"),
-	},
-	Image: ansi.StylePrimitive{
-		Color:     stringPtr("#8be9fd"),
-		Underline: boolPtr(true),
-	},
-	ImageText: ansi.StylePrimitive{
-		Color:  stringPtr("#ff79c6"),
-		Format: "Image: {{.text}} →",
-	},
-	Code: ansi.StyleBlock{
-		StylePrimitive: ansi.StylePrimitive{
-			Color: stringPtr("#50fa7b"),
-		},
-	},
-	CodeBlock: ansi.StyleCodeBlock{
-		StyleBlock: ansi.StyleBlock{
+func CreateReaderStyle(t ThemeConfig) ansi.StyleConfig {
+	return ansi.StyleConfig{
+		Document: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Color: stringPtr("#ffb86c"),
+				BlockSuffix: "\n",
+				Color:       stringPtr(t.SecondaryColor),
 			},
 			Margin: uintPtr(2),
 		},
-		Chroma: &ansi.Chroma{
-			Text: ansi.StylePrimitive{
-				Color: stringPtr("#f8f8f2"),
-			},
-			Error: ansi.StylePrimitive{
-				Color:           stringPtr("#f8f8f2"),
-				BackgroundColor: stringPtr("#ff5555"),
-			},
-			Comment: ansi.StylePrimitive{
-				Color: stringPtr("#6272A4"),
-			},
-			CommentPreproc: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			Keyword: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			KeywordReserved: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			KeywordNamespace: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			KeywordType: ansi.StylePrimitive{
-				Color: stringPtr("#8be9fd"),
-			},
-			Operator: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			Punctuation: ansi.StylePrimitive{
-				Color: stringPtr("#f8f8f2"),
-			},
-			Name: ansi.StylePrimitive{
-				Color: stringPtr("#8be9fd"),
-			},
-			NameBuiltin: ansi.StylePrimitive{
-				Color: stringPtr("#8be9fd"),
-			},
-			NameTag: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			NameAttribute: ansi.StylePrimitive{
-				Color: stringPtr("#50fa7b"),
-			},
-			NameClass: ansi.StylePrimitive{
-				Color: stringPtr("#8be9fd"),
-			},
-			NameConstant: ansi.StylePrimitive{
-				Color: stringPtr("#bd93f9"),
-			},
-			NameDecorator: ansi.StylePrimitive{
-				Color: stringPtr("#50fa7b"),
-			},
-			NameFunction: ansi.StylePrimitive{
-				Color: stringPtr("#50fa7b"),
-			},
-			LiteralNumber: ansi.StylePrimitive{
-				Color: stringPtr("#6EEFC0"),
-			},
-			LiteralString: ansi.StylePrimitive{
-				Color: stringPtr("#f1fa8c"),
-			},
-			LiteralStringEscape: ansi.StylePrimitive{
-				Color: stringPtr("#ff79c6"),
-			},
-			GenericDeleted: ansi.StylePrimitive{
-				Color: stringPtr("#ff5555"),
-			},
-			GenericEmph: ansi.StylePrimitive{
-				Color:  stringPtr("#f1fa8c"),
+		BlockQuote: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:  stringPtr(""),
 				Italic: boolPtr(true),
 			},
-			GenericInserted: ansi.StylePrimitive{
-				Color: stringPtr("#50fa7b"),
-			},
-			GenericStrong: ansi.StylePrimitive{
-				Color: stringPtr("#ffb86c"),
+		},
+		List: ansi.StyleList{
+			LevelIndent: 2,
+		},
+		Heading: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr(t.ReaderHeadingColor),
 				Bold:  boolPtr(true),
 			},
-			GenericSubheading: ansi.StylePrimitive{
-				Color: stringPtr("#bd93f9"),
-			},
-			Background: ansi.StylePrimitive{
-				BackgroundColor: stringPtr("#282a36"),
+		},
+		H1: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "",
 			},
 		},
-	},
-	Table: ansi.StyleTable{
-		StyleBlock: ansi.StyleBlock{
+		H2: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "| ",
+			},
+		},
+		H3: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "",
+			},
+		},
+		H4: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "",
+			},
+		},
+		H5: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "",
+			},
+		},
+		H6: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "",
+			},
+		},
+		Strikethrough: ansi.StylePrimitive{
+			CrossedOut: boolPtr(true),
+		},
+		Emph: ansi.StylePrimitive{
+			Italic: boolPtr(true),
+		},
+		Strong: ansi.StylePrimitive{
+			Bold:  boolPtr(true),
+			Color: stringPtr(t.ReaderHighlightColor),
+		},
+		HorizontalRule: ansi.StylePrimitive{
+			Color:  stringPtr(""),
+			Format: "\n--------\n",
+		},
+		Item: ansi.StylePrimitive{
+			BlockPrefix: "• ",
+		},
+		Enumeration: ansi.StylePrimitive{
+			BlockPrefix: ". ",
+			Color:       stringPtr(""),
+		},
+		Task: ansi.StyleTask{
 			StylePrimitive: ansi.StylePrimitive{},
+			Ticked:         "[✓] ",
+			Unticked:       "[ ] ",
 		},
-		CenterSeparator: stringPtr("┼"),
-		ColumnSeparator: stringPtr("│"),
-		RowSeparator:    stringPtr("─"),
-	},
-	DefinitionDescription: ansi.StylePrimitive{
-		BlockPrefix: "\n🠶 ",
-	},
+		Link: ansi.StylePrimitive{
+			Color:     stringPtr(""),
+			Underline: boolPtr(true),
+		},
+		LinkText: ansi.StylePrimitive{
+			Color: stringPtr(""),
+		},
+		Image: ansi.StylePrimitive{
+			Color:     stringPtr(""),
+			Underline: boolPtr(true),
+		},
+		ImageText: ansi.StylePrimitive{
+			Color:  stringPtr(""),
+			Format: "Image: {{.text}} →",
+		},
+		Code: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr(""),
+			},
+		},
+		Table: ansi.StyleTable{
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{},
+			},
+			CenterSeparator: stringPtr("┼"),
+			ColumnSeparator: stringPtr("│"),
+			RowSeparator:    stringPtr("─"),
+		},
+		DefinitionDescription: ansi.StylePrimitive{
+			BlockPrefix: "\n🠶 ",
+		},
+	}
 }
 
 func boolPtr(b bool) *bool       { return &b }

--- a/pkg/config/style.go
+++ b/pkg/config/style.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/charmbracelet/glamour/ansi"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -32,17 +33,21 @@ type Style struct {
 	// The breaking item state
 	ItemBreakingTitle lipgloss.Style
 	ItemBreakingDesc  lipgloss.Style
+
+	ReaderStyle ansi.StyleConfig
 }
 
 func DefaultThemeConfiguration() ThemeConfig {
 	return ThemeConfig{
-		PrimaryColor:           "62",
-		SecondaryColor:         "230",
+		PrimaryColor:           "#3636D1",
+		SecondaryColor:         "#F8F8F2",
 		NormalTitleColor:       "#DDDDDD",
 		NormalDescColor:        "#777777",
 		SelectedPrimaryColor:   "#AD58B4",
 		SelectedSecondaryColor: "#EE6FF8",
 		BreakingColor:          "#FF0000",
+		ReaderHighlightColor:   "#FFB86C",
+		ReaderHeadingColor:     "#BD93F9",
 	}
 }
 
@@ -95,6 +100,8 @@ func NewsStyle(t ThemeConfig) (s Style) {
 	s.ItemBreakingTitle = lipgloss.NewStyle().Foreground(breakingColor).Padding(0, 0, 0, 2)
 
 	s.ItemBreakingDesc = s.ItemBreakingTitle.Copy().Foreground(breakingColor)
+
+	s.ReaderStyle = CreateReaderStyle(t)
 
 	return s
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -112,9 +112,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tagesschau.News:
 		m.news = tagesschau.News(msg)
 		m.InitLists([][]tagesschau.NewsEntry{m.news.NationalNews, m.news.RegionalNews})
+		width, _ := m.listSelectorDims()
 		for i := range m.lists {
-			width, _ := m.listInnerDims()
 			m.lists[i].Title = lipgloss.PlaceHorizontal(width, lipgloss.Center, headerText)
+			m.lists[i].Styles.Title = m.style.TitleActiveStyle
 		}
 		m.ready = true
 	case tea.KeyMsg:
@@ -176,7 +177,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lists[m.activeListIndex], cmd = m.lists[m.activeListIndex].Update(msg)
 		cmds = append(cmds, cmd)
 		m.listsActiveIndeces[m.activeListIndex] = m.lists[m.activeListIndex].Index()
-		m.reader.SetContent(util.ContentToText(m.SelectedArticle().Content, m.reader.Width))
+		m.reader.SetContent(util.ContentToText(m.SelectedArticle().Content, m.reader.Width, m.style))
 	}
 
 	return m, tea.Batch(cmds...)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,12 +10,12 @@ import (
 	"github.com/zMoooooritz/Nachrichten/pkg/tagesschau"
 )
 
-func ContentToText(content []tagesschau.Content, width int) string {
+func ContentToText(content []tagesschau.Content, width int, s config.Style) string {
 	converter := md.NewConverter("", true, nil)
 	renderer, _ := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 		glamour.WithWordWrap(width),
-		glamour.WithStyles(config.NachrichtenStyleConfig),
+		glamour.WithStyles(s.ReaderStyle),
 	)
 
 	prevType := "text"


### PR DESCRIPTION
Allow the user to theme the actual news reader.
For now this only allows to configure the colors used but now the representation of the markdown